### PR TITLE
Return a single local frame for multiple molecule

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To generate local frames for a molecule, use the following arguments:
 - `-o`, `--output` : The file to write the local frame to. Default is `local_frame.txt`.
 - `--use-ecfp` : Use the ECFP (Extended Connectivity FingerPrint) algorithm instead of the original one for faster symmetry class computation.
 - `--radius` : If the ECFP option is on, the ECFP radius. The default is `3`.
+- `--return_single_molecule`: Return the local frame as if only a single molecule was present in the case of a multi-molecule XYZ file. Use with `--xyz` and `--use_ecfp`.
 - `-v`, `--verbose` : Print the local frame to the console.
 - `--debug` : Print debug information. Compare to the Poltype local frame.
 - `-h`, `--help`: Display the CLI help.
@@ -123,6 +124,7 @@ It is possible to compute the rotation matrix from the topology and coordinates 
    ```python
    from sulley.extract_neighbors import load_molecule_from_tinker_xyz
    from sulley.local_frame import generate_local_frame
+   from sulley.rotation_matrix import compute_rotation_matrix
 
    xyz = 'PATH_TO_XYZ_FILE'
    mol = load_molecule_from_tinker_xyz(xyz)

--- a/src/sulley/extract_neighbors.py
+++ b/src/sulley/extract_neighbors.py
@@ -87,13 +87,18 @@ def parse_tinker_xyz(filename: str):
 
     return atom, bonds
 
-def load_molecule_from_tinker_xyz(filename: str):
+def load_molecule_from_tinker_xyz(
+        filename: str,
+        return_single_molecule = False
+    ):
     """Load a molecule from a Tinker .xyz file.
 
     Parameters
     ----------
     filename : str
         Name of the .xyz file.
+    return_single_molecule : bool
+        If True, return a single molecule even if multiple molecules are present.
 
     Returns
     -------
@@ -146,9 +151,8 @@ def load_molecule_from_tinker_xyz(filename: str):
         atom.SetNoImplicit(True)
         atom.UpdatePropertyCache(strict=False)
 
-    
     # If multiple molecules are present return list of molecules
-    if not is_single_molecule(mol):
+    if not is_single_molecule(mol) and not return_single_molecule:
         mols = split_multimolecules(mol)
         return mols
         

--- a/src/sulley/local_frame.py
+++ b/src/sulley/local_frame.py
@@ -37,23 +37,31 @@ def generate_local_frame(mol, filename=None, use_ecfp=False, radius=3):
     local_frame = []
     for mol in frags:
         local_frame.extend(
-            generate_local_frame_single_mol(mol, filename=filename, use_ecfp=use_ecfp, radius=radius)
+            generate_local_frame_single_mol(
+                mol,
+                use_ecfp=use_ecfp,
+                radius=radius
+            )
         )
     # Handle multiple local frames
     if len(frags) > 1:
         local_frame = write_file.shift_multiple_local_frame(local_frame)
+    
+    if filename is not None:
+        write_file.write_peditin_file(
+            output_local_frame=local_frame,
+            filename = filename
+        )
         
     return local_frame
 
-def generate_local_frame_single_mol(mol, filename=None, use_ecfp=False, radius=3):
+def generate_local_frame_single_mol(mol, use_ecfp=False, radius=3):
     """Generate the local frame for a single molecule.
 
     Parameters
     ----------
     mol : rdkit.Chem.rdchem.Mol
         The molecule for which to generate the local frame.
-    filename : str, optional
-        The name of the file to write the local frame to. If None, the local frame is not written to a file.
     use_ecfp : bool, optional
         Whether to use the ECFP method to generate the symmetry classes. Default is False.
     radius : int, optional
@@ -495,18 +503,12 @@ def generate_local_frame_single_mol(mol, filename=None, use_ecfp=False, radius=3
                 local_frame1[atom_index] = sorted_unique_neighbors_no_repeat_new[0] + 1
                 local_frame2[atom_index] = sorted_unique_neighbors_no_repeat_new[1] + 1
     
-    # Write the local frame file
+    # Output the local frame in correct format
     local_frame = write_file.local_frame_to_output(
         mol,
         idx_to_bisec_then_z_bool, idx_to_trisec_bool,
         idx_to_bisec_idx, idx_to_trisec_idx,
         local_frame1, local_frame2,
-        )
-    if filename is not None:
-
-        write_file.write_peditin_file(
-            output_local_frame=local_frame,
-            filename = filename
         )
 
     return local_frame

--- a/src/sulley/sulley.py
+++ b/src/sulley/sulley.py
@@ -24,7 +24,10 @@ def main(args=None):
     if args.sdf:
         mol = load_molecule_from_sdf(args.sdf)
     if args.xyz:
-        mol = load_molecule_from_tinker_xyz(args.xyz)
+        mol = load_molecule_from_tinker_xyz(
+            filename=args.xyz,
+            return_single_molecule=args.return_single_molecule
+        )
         if type(mol) is list:
             for i, m in enumerate(mol):
                 print(f"Generating local frame for molecule {i+1}...")
@@ -37,7 +40,11 @@ def main(args=None):
                 print(f"Local frame written to {args.output.replace('.txt', f'_{i+1}.txt')}.")
             return local_frame
 
-    local_frame = generate_local_frame(mol=mol, filename=args.output, use_ecfp=args.use_ecfp, radius=args.radius)
+    local_frame = generate_local_frame(
+        mol=mol, filename=args.output,
+        use_ecfp=args.use_ecfp,
+        radius=args.radius
+    )
 
     print(f"Local frame written to {args.output}.")
 
@@ -107,6 +114,11 @@ def cli():
         type=int,
         help='The ECFP radius. Default is 3.',
         default=3,
+    )
+    parser.add_argument(
+        '--return_single_molecule',
+        action='store_true',
+        help='Return the local frame of a single molecule in the case of a multi-molecule XYZ file. Use with --xyz and --use_ecfp.'
     )
     parser.add_argument(
         '-v',


### PR DESCRIPTION
SULLEY should be able to return a single local frame even if multiple molecule are present in the xyz file. New argument has been added to the CLI.